### PR TITLE
CI: Add GolangCI Lint GitHub Actions job

### DIFF
--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -1,0 +1,29 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+      - name: Dummy frontend
+        run: |
+          mkdir 'frontend/dist/'
+          touch 'frontend/dist/dummy'
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.11.2
+          only-new-issues: true


### PR DESCRIPTION
Adds a basic CI job that runs golangci-lint on PRs and pushes on the main branch.

(Requires stubbing out the frontend/dist folder to make go:embed happy)